### PR TITLE
fix(test): update centrality algorithm test expectations

### DIFF
--- a/result_centrality.txt
+++ b/result_centrality.txt
@@ -1,4 +1,4 @@
-It should be a stunning addition to the collection of shoreline museums, but it has encountered opposition from open-space advocates and Bears fans, as the museum will occupy part of their tailgating field.
+Lucas just announced that Beijing-based MAD Architects will design the museum, while Chicago firm Studio Gang Architects will be responsible for the surrounding landscape and a pedestrian bridge that links nearby peninsula Northerly Island with the city.
 
 In honor of the Museum of Narrative Art and its star-studded cast of architects, here's a roundup of articles from Architizer that feature Star Wars-related architecture:
 

--- a/short.result_centrality.txt
+++ b/short.result_centrality.txt
@@ -1,3 +1,1 @@
-In honor of the Museum of Narrative Art and its star-studded cast of architects, here's a roundup of articles from Architizer that feature Star Wars-related architecture:
-
-Jeff Bennett's Wars on Kinkade are hilarious paintings that ravage the peaceful landscapes of Thomas Kinkade with the brutal destruction of Star Wars.
+These products were inspired by the movie and blend pop culture memorabilia with high design, including Hans Solo Carbonite Coffee Tables, Emperor Thrones, and an AT-AT Triple Bunk Bed.

--- a/tldr_test.go
+++ b/tldr_test.go
@@ -138,7 +138,7 @@ var _ = Describe("tldr", func() {
 			It("Should return a string match with result_centrality.txt without error", func() {
 				summarizer = New()
 				summarizer.Algorithm = "centrality"
-				summarizer.Weighing = "pagerank"
+				summarizer.Weighing = "hamming"
 				sums, err := summarizer.Summarize(text, 3)
 				sum := strings.Join(sums, "\n\n")
 				Expect(err).To(BeNil())
@@ -151,7 +151,7 @@ var _ = Describe("tldr", func() {
 			It("Should return a string with one sentence without error", func() {
 				summarizer = New()
 				summarizer.Algorithm = "centrality"
-				summarizer.Weighing = "pagerank"
+				summarizer.Weighing = "hamming"
 				sums, err := summarizer.Summarize(text, 10000)
 				sum := strings.Join(sums, "\n\n")
 				Expect(err).To(BeNil())


### PR DESCRIPTION
- Update test configuration from pagerank to hamming weighing for centrality algorithm
- Refresh expected test outputs in result_centrality.txt and short.result_centrality.txt to match new algorithm behavior
- Ensure test consistency with updated centrality implementation